### PR TITLE
Added changes by grese

### DIFF
--- a/auth0/resource_auth0_connection.go
+++ b/auth0/resource_auth0_connection.go
@@ -408,6 +408,62 @@ var connectionSchema = map[string]*schema.Schema{
 					},
 				},
 
+				// custom sms gateway options
+				"provider": {
+					Type:        schema.TypeString,
+					Optional:    true,
+					Description: "Defines the custom sms_gateway provider",
+					ValidateFunc: validation.StringInSlice([]string{
+						"sms_gateway",
+					}, false),
+				},
+				"gateway_url": {
+					Type:        schema.TypeString,
+					Optional:    true,
+					Description: "Defines a custom sms gateway to use instead of twilio",
+				},
+				"gateway_authentication": {
+					Type:        schema.TypeList,
+					MaxItems:    1,
+					Optional:    true,
+					Description: "Defines the parameters used to generate the auth token for the custom gateway",
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"method": {
+								Type:        schema.TypeString,
+								Optional:    true,
+								Description: "Authentication method (default is bearer token)",
+							},
+							"subject": {
+								Type:        schema.TypeString,
+								Optional:    true,
+								Description: "Subject claim for the HS256 token sent to gateway_url",
+							},
+							"audience": {
+								Type:        schema.TypeString,
+								Optional:    true,
+								Description: "Audience claim for the HS256 token sent to gateway_url",
+							},
+							"secret": {
+								Type:        schema.TypeString,
+								Optional:    true,
+								Description: "Secret used to sign the HS256 token sent to gateway_url",
+							},
+							"secret_base64_encoded": {
+								Type:        schema.TypeBool,
+								Optional:    true,
+								Description: "Specifies whether or not the secret is base64 encoded",
+							},
+						},
+					},
+				},
+				"forward_request_info": {
+					Type:        schema.TypeBool,
+					Optional:    true,
+					Description: "Specifies whether or not request info should be forwarded to sms gateway",
+				},
+
+
 				"set_user_root_attributes": {
 					Type:     schema.TypeString,
 					Optional: true,

--- a/auth0/resource_auth0_connection_test.go
+++ b/auth0/resource_auth0_connection_test.go
@@ -595,6 +595,66 @@ resource "auth0_connection" "sms" {
 }
 `
 
+func TestAccConnectionCustomSMS(t *testing.T) {
+
+	rand := random.String(6)
+
+	resource.Test(t, resource.TestCase{
+		Providers: map[string]terraform.ResourceProvider{
+			"auth0": Provider(),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: random.Template(testAccConnectionCustomSMSConfig, rand),
+				Check: resource.ComposeTestCheckFunc(
+					random.TestCheckResourceAttr("auth0_connection.sms", "name", "Acceptance-Test-Custom-SMS-{{.random}}", rand),
+					resource.TestCheckResourceAttr("auth0_connection.sms", "strategy", "sms"),
+					resource.TestCheckResourceAttr("auth0_connection.sms", "options.0.totp.#", "1"),
+					resource.TestCheckResourceAttr("auth0_connection.sms", "options.0.totp.0.time_step", "300"),
+					resource.TestCheckResourceAttr("auth0_connection.sms", "options.0.totp.0.length", "6"),
+					resource.TestCheckResourceAttr("auth0_connection.sms", "options.0.gateway_url", "https://somewhere.com/sms-gateway"),
+					resource.TestCheckResourceAttr("auth0_connection.sms", "options.0.gateway_authentication.#", "1"),
+					resource.TestCheckResourceAttr("auth0_connection.sms", "options.0.gateway_authentication.0.method", "bearer"),
+					resource.TestCheckResourceAttr("auth0_connection.sms", "options.0.gateway_authentication.0.subject", "test.us.auth0.com:sms"),
+					resource.TestCheckResourceAttr("auth0_connection.sms", "options.0.gateway_authentication.0.audience", "https://somewhere.com/sms-gateway"),
+					resource.TestCheckResourceAttr("auth0_connection.sms", "options.0.gateway_authentication.0.secret", "4e2680bb72ec2ae24836476dd37ed6c2"),
+				),
+			},
+		},
+	})
+}
+
+const testAccConnectionCustomSMSConfig = `
+resource "auth0_connection" "sms" {
+	name = "Acceptance-Test-Custom-SMS-{{.random}}"
+	is_domain_connection = false
+	strategy = "sms"
+	options {
+		disable_signup = false
+		name = "sms"
+		from = "+12345678"
+		syntax = "md_with_macros"
+		template = "@@password@@"
+		brute_force_protection = true
+		totp {
+			time_step = 300
+			length = 6
+		}
+		provider = "sms_gateway"
+		gateway_url = "https://somewhere.com/sms-gateway"
+		gateway_authentication {
+			method = "bearer"
+			subject = "test.us.auth0.com:sms"
+			audience = "https://somewhere.com/sms-gateway"
+			secret = "4e2680bb72ec2ae24836476dd37ed6c2"
+			secret_base64_encoded = false
+		}
+		forward_request_info = true
+	}
+}
+`
+
+
 func TestAccConnectionEmail(t *testing.T) {
 
 	rand := random.String(6)

--- a/auth0/structure_auth0_connection.go
+++ b/auth0/structure_auth0_connection.go
@@ -171,6 +171,15 @@ func flattenConnectionOptionsSMS(o *management.ConnectionOptionsSMS) interface{}
 			"time_step": o.OTP.GetTimeStep(),
 			"length":    o.OTP.GetLength(),
 		},
+		"provider":    o.GetProvider(),
+		"gateway_url": o.GetGatewayUrl(),
+		"gateway_authentication": map[string]interface{}{
+			"method":                o.GatewayAuthentication.GetMethod(),
+			"subject":               o.GatewayAuthentication.GetSubject(),
+			"audience":              o.GatewayAuthentication.GetAudience(),
+			"secret_base64_encoded": o.GatewayAuthentication.GetSecretBase64Encoded(),
+		},
+		"forward_request_info": o.GetForwardRequestInfo(),
 	}
 }
 
@@ -519,6 +528,9 @@ func expandConnectionOptionsSMS(d ResourceData) *management.ConnectionOptionsSMS
 		TwilioSID:            String(d, "twilio_sid"),
 		TwilioToken:          String(d, "twilio_token"),
 		MessagingServiceSID:  String(d, "messaging_service_sid"),
+		Provider:             String(d, "provider"),
+		GatewayUrl:           String(d, "gateway_url"),
+		ForwardRequestInfo:   Bool(d, "forward_request_info"),
 		DisableSignup:        Bool(d, "disable_signup"),
 		BruteForceProtection: Bool(d, "brute_force_protection"),
 	}
@@ -529,6 +541,17 @@ func expandConnectionOptionsSMS(d ResourceData) *management.ConnectionOptionsSMS
 			Length:   Int(d, "length"),
 		}
 	})
+
+	List(d, "gateway_authentication").Elem(func(d ResourceData) {
+		o.GatewayAuthentication = &management.ConnectionGatewayAuthentication{
+			Method:              String(d, "method"),
+			Subject:             String(d, "subject"),
+			Audience:            String(d, "audience"),
+			Secret:              String(d, "secret"),
+			SecretBase64Encoded: Bool(d, "secret_base64_encoded"),
+		}
+	})
+
 
 	return o
 }


### PR DESCRIPTION
Ref PR - https://github.com/alexkappa/terraform-provider-auth0/pull/417


Proposed Changes
Added support for custom sms gateway to the auth0_connection resource as described in #416. The process for setting up a custom SMS gateway is described in this auth0 post.

NOTE: This PR relies on go-auth0/auth0 #230.

Added provider to auth0_connection resource (to specify a custom sms provider such as "sms_gateway")
Added gateway_url to auth0_connection resource (for the url for the sms gateway)
Added gateway_authentication block to auth0_connection resource (settings for the HS256 token sent to sms gateway). The block supports...
method (authentication method for the custom gateway - e.g. "bearer")
subject (subject claim for the token sent to custom gateway)
audience (audience claim for the token sent to custom gateway)
secret (secret used to sign the token sent to custom gateway)
secret_base64_encoded (specifies whether or not the secret is base64 encoded)
Added forward_request_info to auth0_connection resource (specifies that request info such as ip and user-agent should be forwarded to the sms gateway)
Terraform Configuration
resource "auth0_connection" "custom_sms_connection" {
  name     = "sms"
  strategy = "sms"
  ...
  options {
    provider    = "sms_gateway"
    gateway_url = "https://test.com/sms-gateway"
    gateway_authentication {
      method                = "bearer"
      subject               = "test.us.auth0.com:sms"
      audience              = "https://test.com/sms-gateway"
      secret                = "<My Shared Secret>"
      secret_base64_encoded = false
    }
    forward_request_info = true
    ...
  }
}